### PR TITLE
fix: display errors if no tests was executed

### DIFF
--- a/src/base_reporter.ts
+++ b/src/base_reporter.ts
@@ -88,7 +88,7 @@ export abstract class BaseReporter {
   async printSummary(summary: ReturnType<Runner<any>['getSummary']>) {
     console.log('')
 
-    if (summary.aggregates.total === 0) {
+    if (summary.aggregates.total === 0 && !summary.hasError) {
       console.log(logger.colors.bgYellow().black(' NO TESTS EXECUTED '))
       return
     }


### PR DESCRIPTION
If an error is thrown in the `group.setup` hook then no test was executed. It is totally normal.
However, when the SpecReporter report was printed, there was no error displayed, and just a "NO TEST EXECUTED". This PR fixes that. 

I will merge and publish since it's a fairly simple change. Let me know if I shouldn't have